### PR TITLE
Added nesting highlights, popup notes, and translation links.

### DIFF
--- a/containers/web/src/jboski.py
+++ b/containers/web/src/jboski.py
@@ -36,12 +36,25 @@ def parse(text):
     content = content.replace('<SUB><FONT SIZE="-3">', '<sub class="parenmark">')
     content = content.replace('</FONT></SUB>', '</sub>')
     # 🅐
+
+    """
+    # Tried to move the tooltips onto the words themselves, but some words don't have translation asterisks, so that broke things
+    content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
+    content = content.replace('</FONT></U>', '</em></em>')
+    content = content.replace('<I>', '<em class="translation tooltiptext">')
+    content = content.replace('</I>', '</strong></em></em>')
+    # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
+    content = re.sub('<B>(.*?)</B>', '<strong class="lojban tooltip"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a>', content)
+    """
+
     content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
     content = content.replace('</FONT></U>', '</em></em>')
     content = content.replace('<I>', '<em class="translation tooltip">*<em class="translation tooltiptext">')
     content = content.replace('</I>', '</em></em>')
     # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
     content = re.sub('<B>(.*?)</B>', '<strong class="lojban"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a></strong>', content)
+
+
     content = content.replace('&gt;&gt;', '&raquo;')
     content = content.replace('&lt;&lt;', '&laquo;')
     content = content.replace('<P>', '<br />')

--- a/containers/web/src/jboski.py
+++ b/containers/web/src/jboski.py
@@ -29,9 +29,14 @@ def parse(text, mode):
     
     if len(child_stderr) > 0:
         return False, '<pre class="translationerror">' + child_stderr.decode() + '</pre>'
-    
-    if mode == "condensed":
-        # Condensed
+
+    if mode == "plain":
+        # Plain
+        content = child_stdout.decode()
+        content = re.sub(r'^.*<BODY>\s*\n', '', content, flags=re.DOTALL)
+        content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
+    elif mode == "condensed_robust":
+        # Condensed (robust)
         content = child_stdout.decode()
         content = re.sub(r'^.*<BODY>\s*\n', '', content, flags=re.DOTALL)
         content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
@@ -66,6 +71,44 @@ def parse(text, mode):
         content = content.replace('&lt;', '&lt;<span class="colornest colornest_angle">')
         content = content.replace('&gt;', '</span>&gt;')
         #content = content + "<br/>(mode: " + mode + ")"
+    elif mode == "condensed":
+        # Condensed
+        content = child_stdout.decode()
+        content = re.sub(r'^.*<BODY>\s*\n', '', content, flags=re.DOTALL)
+        content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
+        content = content.replace('<SUB><FONT SIZE="-3">', '<sub class="parenmark">')
+        content = content.replace('</FONT></SUB>', '</sub>')
+
+
+        # Tried to move the tooltips onto the words themselves, but some words don't have translation asterisks, so that broke things
+        content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
+        content = content.replace('</FONT></U>', '</em></em>')
+        # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
+        content = re.sub('<B>([^<>]*?)</B>\\n<I>([^<>]*?)</I>', '<strong class="lojban tooltip"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a><em class="translation tooltiptext">\\2</em></strong>', content)
+        content = re.sub('<B>(.*?)</B>', '<strong class="lojban"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a></strong>', content)
+        content = content.replace('<I>', '<em class="translation tooltip">*<em class="translation tooltiptext">')
+        content = content.replace('</I>', '</em></em>')
+
+        """
+        content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
+        content = content.replace('</FONT></U>', '</em></em>')
+        content = content.replace('<I>', '<em class="translation tooltip">*<em class="translation tooltiptext">')
+        content = content.replace('</I>', '</em></em>')
+        # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
+        content = re.sub('<B>(.*?)</B>', '<strong class="lojban"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a></strong>', content)
+        """
+
+
+        content = content.replace('&gt;&gt;', '&raquo;')
+        content = content.replace('&lt;&lt;', '&laquo;')
+        content = content.replace('<P>', '<br />')
+        content = content.replace('[', '[<span class="colornest colornest_square">')
+        content = content.replace(']', '</span>]')
+        content = content.replace('(', '(<span class="colornest colornest_round">')
+        content = content.replace(')', '</span>)')
+        content = content.replace('&lt;', '&lt;<span class="colornest colornest_angle">')
+        content = content.replace('&gt;', '</span>&gt;')
+        #content = content + "<br/>(mode: " + mode + ")"
     else:
         # Expanded
         content = child_stdout.decode()
@@ -85,9 +128,6 @@ def parse(text, mode):
     
 
     return True, content
-
-def asdf():
-    "asdfasdf"
 
 @app.route('/')
 def index():

--- a/containers/web/src/jboski.py
+++ b/containers/web/src/jboski.py
@@ -19,7 +19,7 @@ app.logger.addHandler(stream_handler)
 #
 # The actual substitutions we do here came from the original jboski
 # https://lojban.org/jboski/index.php.txt by Raphaël Poss <r.poss@online.fr>
-def parse(text):
+def parse(text, mode):
     
     p = Popen("jbofihe -H", shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
     p.stdin.write(text.encode())
@@ -64,16 +64,21 @@ def parse(text):
     content = content.replace(')', '</span>)')
     content = content.replace('&lt;', '&lt;<span class="colornest colornest_angle">')
     content = content.replace('&gt;', '</span>&gt;')
+    content = content + "<br/>(mode: " + mode + ")"
     
     return True, content
+
+def asdf():
+    "asdfasdf"
 
 @app.route('/')
 def index():
     text = request.args.get('text', "coi pilno mi'e jboski")
+    mode = request.args.get('mode', "contracted")
     grammatical = False
     parsed = ''
     try:
-        grammatical, parsed = parse(text)
+        grammatical, parsed = parse(text, mode)
     except Exception as e:
         import traceback
         return "<pre>Exception thrown: " + "\n".join(traceback.format_exception(None, e, e.__traceback__)) + "</pre>"

--- a/containers/web/src/jboski.py
+++ b/containers/web/src/jboski.py
@@ -45,11 +45,11 @@ def parse(text):
     content = content.replace('&gt;&gt;', '&raquo;')
     content = content.replace('&lt;&lt;', '&laquo;')
     content = content.replace('<P>', '<br />')
-    content = content.replace('[', '[<span class="colornest_square">')
+    content = content.replace('[', '[<span class="colornest colornest_square">')
     content = content.replace(']', '</span>]')
-    content = content.replace('(', '(<span class="colornest_round">')
+    content = content.replace('(', '(<span class="colornest colornest_round">')
     content = content.replace(')', '</span>)')
-    content = content.replace('&lt;', '&lt;<span class="colornest_angle">')
+    content = content.replace('&lt;', '&lt;<span class="colornest colornest_angle">')
     content = content.replace('&gt;', '</span>&gt;')
     
     return True, content

--- a/containers/web/src/jboski.py
+++ b/containers/web/src/jboski.py
@@ -30,42 +30,60 @@ def parse(text, mode):
     if len(child_stderr) > 0:
         return False, '<pre class="translationerror">' + child_stderr.decode() + '</pre>'
     
-    content = child_stdout.decode()
-    content = re.sub(r'^.*<BODY>\s*\n', '', content, flags=re.DOTALL)
-    content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
-    content = content.replace('<SUB><FONT SIZE="-3">', '<sub class="parenmark">')
-    content = content.replace('</FONT></SUB>', '</sub>')
-    # 🅐
+    if mode == "condensed":
+        # Condensed
+        content = child_stdout.decode()
+        content = re.sub(r'^.*<BODY>\s*\n', '', content, flags=re.DOTALL)
+        content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
+        content = content.replace('<SUB><FONT SIZE="-3">', '<sub class="parenmark">')
+        content = content.replace('</FONT></SUB>', '</sub>')
+ 
+        """
+        # Tried to move the tooltips onto the words themselves, but some words don't have translation asterisks, so that broke things
+        content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
+        content = content.replace('</FONT></U>', '</em></em>')
+        content = content.replace('<I>', '<em class="translation tooltiptext">')
+        content = content.replace('</I>', '</strong></em></em>')
+        # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
+        content = re.sub('<B>(.*?)</B>', '<strong class="lojban tooltip"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a>', content)
+        """
 
-    """
-    # Tried to move the tooltips onto the words themselves, but some words don't have translation asterisks, so that broke things
-    content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
-    content = content.replace('</FONT></U>', '</em></em>')
-    content = content.replace('<I>', '<em class="translation tooltiptext">')
-    content = content.replace('</I>', '</strong></em></em>')
-    # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
-    content = re.sub('<B>(.*?)</B>', '<strong class="lojban tooltip"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a>', content)
-    """
-
-    content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
-    content = content.replace('</FONT></U>', '</em></em>')
-    content = content.replace('<I>', '<em class="translation tooltip">*<em class="translation tooltiptext">')
-    content = content.replace('</I>', '</em></em>')
-    # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
-    content = re.sub('<B>(.*?)</B>', '<strong class="lojban"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a></strong>', content)
+        content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
+        content = content.replace('</FONT></U>', '</em></em>')
+        content = content.replace('<I>', '<em class="translation tooltip">*<em class="translation tooltiptext">')
+        content = content.replace('</I>', '</em></em>')
+        # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
+        content = re.sub('<B>(.*?)</B>', '<strong class="lojban"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a></strong>', content)
 
 
-    content = content.replace('&gt;&gt;', '&raquo;')
-    content = content.replace('&lt;&lt;', '&laquo;')
-    content = content.replace('<P>', '<br />')
-    content = content.replace('[', '[<span class="colornest colornest_square">')
-    content = content.replace(']', '</span>]')
-    content = content.replace('(', '(<span class="colornest colornest_round">')
-    content = content.replace(')', '</span>)')
-    content = content.replace('&lt;', '&lt;<span class="colornest colornest_angle">')
-    content = content.replace('&gt;', '</span>&gt;')
-    content = content + "<br/>(mode: " + mode + ")"
+        content = content.replace('&gt;&gt;', '&raquo;')
+        content = content.replace('&lt;&lt;', '&laquo;')
+        content = content.replace('<P>', '<br />')
+        content = content.replace('[', '[<span class="colornest colornest_square">')
+        content = content.replace(']', '</span>]')
+        content = content.replace('(', '(<span class="colornest colornest_round">')
+        content = content.replace(')', '</span>)')
+        content = content.replace('&lt;', '&lt;<span class="colornest colornest_angle">')
+        content = content.replace('&gt;', '</span>&gt;')
+        #content = content + "<br/>(mode: " + mode + ")"
+    else:
+        # Expanded
+        content = child_stdout.decode()
+        content = re.sub(r'^.*<BODY>\s*\n', '', content, flags=re.DOTALL)
+        content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
+        content = content.replace('<SUB><FONT SIZE="-3">', '<sub class="parenmark">')
+        content = content.replace('</FONT></SUB>', '</sub>')
+        content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace">')
+        content = content.replace('</FONT></U>', '</em>')
+        content = content.replace('<I>', '<em class="translation">')
+        content = content.replace('</I>', '</em>')
+        content = content.replace('<B>', '<strong class="lojban">')
+        content = content.replace('</B>', '</strong>')
+        content = content.replace('&gt;&gt;', '&raquo;')
+        content = content.replace('&lt;&lt;', '&laquo;')
+        content = content.replace('<P>', '<br />')
     
+
     return True, content
 
 def asdf():
@@ -74,7 +92,7 @@ def asdf():
 @app.route('/')
 def index():
     text = request.args.get('text', "coi pilno mi'e jboski")
-    mode = request.args.get('mode', "contracted")
+    mode = request.args.get('mode', "condensed")
     grammatical = False
     parsed = ''
     try:

--- a/containers/web/src/jboski.py
+++ b/containers/web/src/jboski.py
@@ -35,15 +35,22 @@ def parse(text):
     content = re.sub(r'</BODY>\s*$', '', content, flags=re.DOTALL)
     content = content.replace('<SUB><FONT SIZE="-3">', '<sub class="parenmark">')
     content = content.replace('</FONT></SUB>', '</sub>')
-    content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace">')
-    content = content.replace('</FONT></U>', '</em>')
-    content = content.replace('<I>', '<em class="translation">')
-    content = content.replace('</I>', '</em>')
-    content = content.replace('<B>', '<strong class="lojban">')
-    content = content.replace('</B>', '</strong>')
+    # 🅐
+    content = content.replace('<U><FONT SIZE=-1>', '<em class="sumtiplace tooltip">*<em class="sumtiplace tooltiptext">')
+    content = content.replace('</FONT></U>', '</em></em>')
+    content = content.replace('<I>', '<em class="translation tooltip">*<em class="translation tooltiptext">')
+    content = content.replace('</I>', '</em></em>')
+    # https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=XYZ
+    content = re.sub('<B>(.*?)</B>', '<strong class="lojban"><a href="https://la-lojban.github.io/sutysisku/lojban/index.html#sisku=\\1">\\1</a></strong>', content)
     content = content.replace('&gt;&gt;', '&raquo;')
     content = content.replace('&lt;&lt;', '&laquo;')
     content = content.replace('<P>', '<br />')
+    content = content.replace('[', '[<span class="colornest_square">')
+    content = content.replace(']', '</span>]')
+    content = content.replace('(', '(<span class="colornest_round">')
+    content = content.replace(')', '</span>)')
+    content = content.replace('&lt;', '&lt;<span class="colornest_angle">')
+    content = content.replace('&gt;', '</span>&gt;')
     
     return True, content
 

--- a/containers/web/src/static/live.js
+++ b/containers/web/src/static/live.js
@@ -30,7 +30,13 @@ $(document).ready(function() {
 
     var jboText = $("#input").val();
     var mode = $("#mode").val();
-    ajaxRequest = $.getJSON("", { mode: mode, text: jboText, json: true }, function(json) {
+    let params;
+    if (jboText) {
+      params = { mode: mode, text: jboText, json: true };
+    } else {
+      params = { mode: mode, json: true };
+    }
+    ajaxRequest = $.getJSON("", params, function(json) {
       $("#output").html(json.html);
       
       if (json.grammatical) {
@@ -40,7 +46,11 @@ $(document).ready(function() {
         if (typeof(window.history) !== "undefined") {
           var link = $("<a/>")[0];
           link.href = window.location.href;
-          link.search = "?mode=" + escape(mode) + "&text=" + escape(jboText);
+          if (jboText) {
+            link.search = "?mode=" + escape(mode) + "&text=" + escape(jboText);
+          } else {
+            link.search = "?mode=" + escape(mode);
+          }
 
           var title = jboText + " -- jboski";
           history.replaceState(null, title, link.href);

--- a/containers/web/src/static/live.js
+++ b/containers/web/src/static/live.js
@@ -25,12 +25,12 @@ var ajaxRequest = null;
 
 $(document).ready(function() {
   
-  $("#input").keyup( debounce( function() {
-
+  let refresh = function() {
     if (ajaxRequest) ajaxRequest.abort();
 
     var jboText = $("#input").val();
-    ajaxRequest = $.getJSON("", { text: jboText, json: true }, function(json) {
+    var mode = $("#mode").val();
+    ajaxRequest = $.getJSON("", { mode: mode, text: jboText, json: true }, function(json) {
       $("#output").html(json.html);
       
       if (json.grammatical) {
@@ -40,7 +40,7 @@ $(document).ready(function() {
         if (typeof(window.history) !== "undefined") {
           var link = $("<a/>")[0];
           link.href = window.location.href;
-          link.search = "?text=" + escape(jboText);
+          link.search = "?mode=" + escape(mode) + "&text=" + escape(jboText);
 
           var title = jboText + " -- jboski";
           history.replaceState(null, title, link.href);
@@ -50,7 +50,10 @@ $(document).ready(function() {
         $("#input").removeClass("grammatical");
       }
     });
-  }, 500, false));
+  };
+
+  $("#input").keyup(debounce(refresh, 500, false));
+  $("#mode").change(refresh);
 });
 
 })(jQuery);

--- a/containers/web/src/static/screen.css
+++ b/containers/web/src/static/screen.css
@@ -3,7 +3,7 @@
 form { position: fixed; }
 .ungrammatical { background: #fcc; }
 #output {
-    padding-top: 4em;
+    padding-top: 5em;
     /* line-height: 1; */
 }
 

--- a/containers/web/src/static/screen.css
+++ b/containers/web/src/static/screen.css
@@ -4,7 +4,7 @@ form { position: fixed; }
 .ungrammatical { background: #fcc; }
 #output {
     padding-top: 4em;
-    line-height: 4;
+    /* line-height: 1; */
 }
 
 /* Unused, from visual-camxes */
@@ -33,24 +33,23 @@ em.sumtiplace {
     color: maroon;
     font-size: small;
 }
+span.colornest {
+    display: inline-block;
+    /* height: 3em; */
+    padding-top: 0.2em;
+    padding-bottom: 0.2em;
+    margin-top: 0.1em;
+    margin-bottom: 0.1em;
+    /* transform: translate(0px, 10px); */
+}
 span.colornest_square {
     background-color: #FF000020;
-    height: 3em;
-    padding-top: 1em;
-    padding-bottom: 1em;
 }
 span.colornest_round {
     background-color: #00FF0020;
-    /*background-color: #FF000040;*/
-    height: 3em;
-    padding-top: 1em;
-    padding-bottom: 1em;
 }
 span.colornest_angle {
     background-color: #0000FF20;
-    height: 3em;
-    padding-top: 1em;
-    padding-bottom: 1em;
 }
 sub.parenmark {
     font-size: xx-small;

--- a/containers/web/src/static/screen.css
+++ b/containers/web/src/static/screen.css
@@ -2,7 +2,10 @@
 
 form { position: fixed; }
 .ungrammatical { background: #fcc; }
-#output { padding-top: 4em; }
+#output {
+    padding-top: 4em;
+    line-height: 4;
+}
 
 /* Unused, from visual-camxes */
 .box {
@@ -30,9 +33,60 @@ em.sumtiplace {
     color: maroon;
     font-size: small;
 }
+span.colornest_square {
+    background-color: #FF000020;
+    height: 3em;
+    padding-top: 1em;
+    padding-bottom: 1em;
+}
+span.colornest_round {
+    background-color: #00FF0020;
+    /*background-color: #FF000040;*/
+    height: 3em;
+    padding-top: 1em;
+    padding-bottom: 1em;
+}
+span.colornest_angle {
+    background-color: #0000FF20;
+    height: 3em;
+    padding-top: 1em;
+    padding-bottom: 1em;
+}
 sub.parenmark {
     font-size: xx-small;
 }
 em.translation {
     color: blue;
+}
+.tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  white-space: nowrap;
+  display: inline-block;
+  /* width: 120px; */
+  background-color: white;
+  /* color: black; */
+  text-align: center;
+  border-radius: 6px;
+  border: green;
+  border-style: solid;
+  padding: 5px 0;
+  /* margin-left: 0%; */
+  /* left: 0em; */
+  transform: translate(-50% , 0%);
+  top: 2.75em;
+  line-height: 1;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
 }

--- a/containers/web/src/templates/index.html
+++ b/containers/web/src/templates/index.html
@@ -29,9 +29,9 @@
       </p>
       <p>
         <label for="mode">Mode:</label>
-        <select name="mode" id="mode" required="required" selected="contracted">
+        <select name="mode" id="mode" required="required" selected="condensed">
           <option value="expanded" {{ ('selected' if request.args.get('mode') == 'expanded' else '') if request.args.get('mode') else '' }}>expanded</option>
-          <option value="contracted" {{ ('selected' if request.args.get('mode') == 'contracted' else '') if request.args.get('mode') else 'selected' }}>contracted</option>
+          <option value="condensed" {{ ('selected' if request.args.get('mode') == 'condensed' else '') if request.args.get('mode') else 'selected' }}>condensed</option>
         </select>
       </p>
     </form>

--- a/containers/web/src/templates/index.html
+++ b/containers/web/src/templates/index.html
@@ -27,6 +27,13 @@
         />
         <a href="static/about.html">About</a>
       </p>
+      <p>
+        <label for="mode">Mode:</label>
+        <select name="mode" id="mode" required="required" selected="contracted">
+          <option value="expanded" {{ ('selected' if request.args.get('mode') == 'expanded' else '') if request.args.get('mode') else '' }}>expanded</option>
+          <option value="contracted" {{ ('selected' if request.args.get('mode') == 'contracted' else '') if request.args.get('mode') else 'selected' }}>contracted</option>
+        </select>
+      </p>
     </form>
 
 

--- a/containers/web/src/templates/index.html
+++ b/containers/web/src/templates/index.html
@@ -30,8 +30,10 @@
       <p>
         <label for="mode">Mode:</label>
         <select name="mode" id="mode" required="required" selected="condensed">
+          <option value="plain" {{ ('selected' if request.args.get('mode') == 'plain' else '') if request.args.get('mode') else '' }}>plain</option>
           <option value="expanded" {{ ('selected' if request.args.get('mode') == 'expanded' else '') if request.args.get('mode') else '' }}>expanded</option>
           <option value="condensed" {{ ('selected' if request.args.get('mode') == 'condensed' else '') if request.args.get('mode') else 'selected' }}>condensed</option>
+          <option value="condensed_robust" {{ ('selected' if request.args.get('mode') == 'condensed_robust' else '') if request.args.get('mode') else '' }}>condensed (robust)</option>
         </select>
       </p>
     </form>


### PR DESCRIPTION
The output showed a lot of useful-looking information, but in a form that was hard to grasp.
So I added transparent colored backgrounds by ()/[]/<> to visually show nesting,
moved the translations to hover-over tooltips,
and made the lojban words link to sutysisku for a full translation.

The highlights are a bit garish, and maybe not as easy-to-understand as they could be, but I'm not immediately sure how to improve them.
I did just have a thought, though, so I'll probably push another commit in a minute.
The colors will likely remain garish, though.

Do you think there should be a checkbox to toggle between the old/new modes, or anything?

Testing it on a few sentences of text, I do feel like the new interface _significantly_ improves understandability.